### PR TITLE
Enable client reuse with Hyper 1.x

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye"
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "common",
+ "futures",
  "http-body-util",
  "hyper 1.1.0",
  "tokio",
@@ -100,12 +101,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -113,6 +130,23 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
@@ -126,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
 name = "futures-task"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,9 +177,13 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",

--- a/client0x/src/main.rs
+++ b/client0x/src/main.rs
@@ -10,6 +10,8 @@ async fn main() {
 
     let client = hyper::client::Client::new(); // variant 1
 
+    println!("Using path: {}", endpoint.path());
+
     for _ in 0..200 {
         //let client = hyper::client::Client::new(); // variant 2
         let mut resp = client.get(endpoint.clone()).await.unwrap();

--- a/client1x/Cargo.toml
+++ b/client1x/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 common = { path = "../common" }
 hyper = { version = "1.1.0", features = ["client", "http1"] }
 tokio = { version = "1.35.1", features = ["full"] }
+futures = "0.3.30"
 
 bytes = "1.5.0"
 http-body-util = "0.1.0"

--- a/run.sh
+++ b/run.sh
@@ -6,22 +6,27 @@ cargo build --release
 PID=$!
 echo "Server running as pid $PID"
 
+ENDPOINT_BASE="http://127.0.0.1:3000"
+# ENDPOINT_BASE="http://host.docker.internal:3000"
 sleep 2
+
+echo ""
+echo "Using ENDPOINT_BASE: $ENDPOINT_BASE"
 
 echo ""
 echo "Hyper<1.0"
 echo "Using regular route"
-./target/release/client0x http://127.0.0.1:3000/regular
+./target/release/client0x "${ENDPOINT_BASE}/regular"
 
 echo "Using stream route"
-./target/release/client0x http://127.0.0.1:3000/stream
+./target/release/client0x "${ENDPOINT_BASE}/stream"
 
 echo ""
 echo "Hyper>=1.0"
 echo "Using regular route"
-./target/release/client1x http://127.0.0.1:3000/regular
+./target/release/client1x "${ENDPOINT_BASE}/regular"
 
 echo "Using stream route"
-./target/release/client1x http://127.0.0.1:3000/stream
+./target/release/client1x "${ENDPOINT_BASE}/stream"
 
 kill $PID


### PR DESCRIPTION
## Overview

- Allowed connection reuse for 1.x
- Fixed bug that would throw `hyper::Error(Canceled, "connection was not ready")` when connection was being reused
   - https://github.com/dice-group/hyper-issue-example/pull/1/files#diff-3dfc70d1f615944d9c91002ab5a11ebce266bba17635c1ace8b91f5aa48308b2R47-R62
- Testing on Linux is on Mac using Docker

## The Canceled Issue was Intermittently Reproducible

The problem was that `send_request` was being called again as soon as the last byte was ready off the response stream.

This is not correct.  `poll_ready` has to be called to ensure that the connection is in a state that allows a request to be sent.  This state change happens asynchronously with reading the last response stream byte, so periodically `send_request` would get called when the last request was still marked as in progress, causing the panic.

A better example of how to reconnect when `poll_ready` throws an error is below.  But note that just waiting for `poll_ready` is sufficient to make this error go away in nominal testing conditions (no network disconnects).

### Example Reconnect Solution

https://github.com/hatoo/oha/blob/44cdfe37a9f7ae9df747ea80d426a59dd93a22d7/src/client.rs#L429-L441

### Request #84 failed to send

<img width="855" alt="image" src="https://github.com/dice-group/hyper-issue-example/assets/5617868/4cfb0195-0a4a-490a-82c9-761b5106a57e">


### The client is the one initiating the socket close, not the server

<img width="1558" alt="image" src="https://github.com/dice-group/hyper-issue-example/assets/5617868/222e7f41-2319-49be-9f00-d7580240eca2">


## After - Mac - NOT Reproducible with 0.x or 1.x

```
Hyper<1.0
Using regular route
Using path: /regular
took: 5.721095208s
Using stream route
Using path: /stream
took: 5.671193541s

Hyper>=1.0
Using regular route
Using path: /regular
took: 5.684051375s
Using stream route
Using path: /stream
took: 5.687132167s
```

## After - Linux - Reproducible with 1.x

```
Hyper<1.0
Using regular route
Using path: /regular
took: 6.289539503s
Using stream route
Using path: /stream
took: 8.736237880000001s

Hyper>=1.0
Using regular route
Using path: /regular
took: 5.99029117s
Using stream route
Using path: /stream
took: 8.787138378s
```

## Before - Linux - NOT Reproducible with 1.x

```
Hyper<1.0
Using regular route
Using path: /regular
took: 6.320107628s
Using stream route
Using path: /stream
took: 8.706223712s

Hyper>=1.0
Using regular route
Using path: /regular
took: 6.389099086s
Using stream route
Using path: /stream
took: 6.171724086s
```