### PR TITLE
Server - Fix connection reuse chunked response delay by disabling Nagle's algorithm (`set_nodelay(true)`)

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -91,15 +91,22 @@ async fn main() {
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
     let listener = TcpListener::bind(addr).await.unwrap();
     let mut printed_nodelay = false;
+    let mut printed_set_nodelay = false;
 
     println!("Listening on http://{addr} routes /stream and /regular");
     loop {
         let (tcp, _) = listener.accept().await.unwrap();
         if !printed_nodelay {
             println!("Default nodelay: {}", tcp.nodelay().unwrap());
+            println!("");
             printed_nodelay = true;
         }
         tcp.set_nodelay(true).unwrap();
+        if !printed_set_nodelay {
+            println!("Set nodelay: {}", tcp.nodelay().unwrap());
+            println!("");
+            printed_set_nodelay = true;
+        }
         let io = TokioIo::new(tcp);
 
         tokio::task::spawn(async move {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -39,7 +39,7 @@ fn generate_data() -> Bytes {
     buf.freeze()
 }
 
-/// Regular route that sends a single chunk as `Full` body
+/// Regular route that sends a `Full` body with a Content-Length header
 async fn hyper_regular() -> Result<Response<BoxBody<Bytes, Infallible>>> {
     let (tx, rx) = oneshot::channel();
 
@@ -56,6 +56,9 @@ async fn hyper_regular() -> Result<Response<BoxBody<Bytes, Infallible>>> {
 async fn hyper_stream() -> Result<Response<BoxBody<Bytes, Infallible>>> {
     let (tx, rx) = mpsc::unbounded_channel();
 
+    // NOTE: Starting a thread is a bit heavy, even though this is using the CPU
+    // in a tight loop.  If this was normal server work this would typically be
+    // a `tokio::task::spawn` instead of `std::thread::spawn``
     std::thread::spawn(move || {
         let data = std::hint::black_box(generate_data());
         let _ = tx.send(Ok::<_, Infallible>(data));
@@ -87,10 +90,16 @@ async fn main() {
 
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
     let listener = TcpListener::bind(addr).await.unwrap();
+    let mut printed_nodelay = false;
 
     println!("Listening on http://{addr} routes /stream and /regular");
     loop {
         let (tcp, _) = listener.accept().await.unwrap();
+        if !printed_nodelay {
+            println!("Default nodelay: {}", tcp.nodelay().unwrap());
+            printed_nodelay = true;
+        }
+        tcp.set_nodelay(true).unwrap();
         let io = TokioIo::new(tcp);
 
         tokio::task::spawn(async move {


### PR DESCRIPTION
## Overview

[Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm) intentionally adds a delay between when bytes are written to a TCP socket (on either end) and when the OS sends those bytes, in an attempt to batch up small writes into less packets.

Note that Nagle's algorithm and the setting that control it are inverted.  `nodelay=true` means Nagle's algorithm is disabled and there is no delay inserted on writes.  `nodelay=false` means Nagle's algorithm is enabled and the delay is inserted.

Nagle's algorithm was introduced in 1984 and it's still `on by default` today!

Nagle's algorithm can be helpful IFF (if and only if) the producer for the TCP socket is unable (or unaware that they should) to write larger blocks of bytes with each call.  I claim Nagle's algorithm should be turned off by all programmers that know what they are doing and are writing large buffers (even if their applications is not an "interactive" application).

I've never made anyone happy by leaving Nagle's algorithm on.  Turn it off, but pay attention to writing in bigger blocks (e.g. 1 KB+ if possible) rather than calling write in tight loops writing 1 byte at a time because it's "easier".

The solution here was to turn off Nagle's algorithm on the `server` as it was inserting a short, but cumulative in the test, delay before flushing the bytes to the response socket.

The issue was reproducible on Linux but not on Mac although both had Nagle's algorithm enabled by default.  The reason for this is probably slight tuning differences in how many bytes each OS thinks should wait for more bytes vs being sent immediately.

## After - Nagle's Algorithm Disabled - No Delays on Chunked Responses

```
Server running as pid 52560
Listening on http://127.0.0.1:3000 routes /stream and /regular

Using ENDPOINT_BASE: http://127.0.0.1:3000

Hyper<1.0
Using regular route
Using path: /regular
Default nodelay: false ❌ 

Set nodelay: true ✅ 

took: 6.139572461s
Using stream route
Using path: /stream
took: 6.015059211s ✅ 

Hyper>=1.0
Using regular route
Using path: /regular
took: 5.937338878s
Using stream route
Using path: /stream
took: 5.954765711s ✅ 
```

## Before - Delays when Reusing Connections on Chunked (Streamed) Responses

Note: this happened only when the `server` was running on Linux.  On Mac OS there was no difference in performance between`/stream` and `/regular` and this probably has to do with a slight difference in the implementation details or settings tuning of Nagle's algorithm across the two OSes.

```
Server running as pid 55182
Listening on http://127.0.0.1:3000 routes /stream and /regular

Using ENDPOINT_BASE: http://127.0.0.1:3000

Hyper<1.0
Using regular route
Using path: /regular
Default nodelay: false ❌ 

Set nodelay: false ❌ 

took: 6.040918837s
Using stream route
Using path: /stream
took: 8.620580588s ❌ 

Hyper>=1.0
Using regular route
Using path: /regular
took: 5.923212336s
Using stream route
Using path: /stream
took: 8.755907796s ❌ 
```